### PR TITLE
flash support for Zyxel devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@
 # * EMBED_CE
 # * EMBED_UBNT
 # * EMBED_UBOOT
+# * EMBED_ZYXEL
 
 BINARY_NAME = ap51-flash
 OBJ += commandline.o
@@ -102,6 +103,7 @@ EMBEDDED_IMAGES += $(EMBED_CI)
 EMBEDDED_IMAGES += $(EMBED_CE)
 EMBEDDED_IMAGES += $(EMBED_UBNT)
 EMBEDDED_IMAGES += $(EMBED_UBOOT)
+EMBEDDED_IMAGES += $(EMBED_ZYXEL)
 
 Makefile: embed_image.mk
 include embed_image.mk
@@ -110,6 +112,7 @@ $(eval $(call embed_image,CI,ci))
 $(eval $(call embed_image,CE,ce))
 $(eval $(call embed_image,UBNT,ubnt))
 $(eval $(call embed_image,UBOOT,uboot))
+$(eval $(call embed_image,ZYXEL,zyxel))
 
 # try to generate revision
 REVISION= $(shell \

--- a/ap51-flash-res.h
+++ b/ap51-flash-res.h
@@ -26,5 +26,6 @@
 #define IDR_CE_IMG 102
 #define IDR_UBNT_IMG 103
 #define IDR_UBOOT_IMG 104
+#define IDR_ZYXEL_IMG 105
 
 #endif /* __AP51_FLASH_RES_H__ */

--- a/commandline.c
+++ b/commandline.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 	if (load_embedded) {
 		router_images_init_embedded();
 	} else {
-#if defined(EMBED_UBOOT) || defined(EMBED_UBNT) || defined(EMBED_CI) || defined(EMBED_CE)
+#if defined(EMBED_UBOOT) || defined(EMBED_UBNT) || defined(EMBED_CI) || defined(EMBED_CE) || defined(EMBED_ZYXEL)
 		printf("Embedded image disabled\n");
 #endif
 	}

--- a/docs/supported-devices/index.rst
+++ b/docs/supported-devices/index.rst
@@ -63,6 +63,10 @@ Tested
 
   - Colibrì (!UniData)
 
+* Zyxel
+
+ - NBG6817
+
 
 Other Devices
 =============

--- a/router_images.h
+++ b/router_images.h
@@ -48,5 +48,6 @@ extern struct router_image img_uboot;
 extern struct router_image img_ubnt;
 extern struct router_image img_ci;
 extern struct router_image img_ce;
+extern struct router_image img_zyxel;
 
 #endif /* __AP51_FLASH_ROUTER_IMAGES_H__ */

--- a/router_tftp_client.h
+++ b/router_tftp_client.h
@@ -39,6 +39,7 @@ extern const struct router_type  om5p;
 extern const struct router_type  om5pac;
 extern const struct router_type  om5pan;
 extern const struct router_type  p60;
+extern const struct router_type  zyxel;
 
 void tftp_client_flash_time_set(struct node *node);
 int tftp_client_flash_completed(struct node *node);

--- a/router_types.c
+++ b/router_types.c
@@ -56,6 +56,7 @@ static const struct router_type *router_types[] = {
 	&p60,
 	&redboot,
 	&ubnt,
+	&zyxel,
 	NULL,
 };
 

--- a/types.h
+++ b/types.h
@@ -54,6 +54,7 @@ enum image_type {
 	IMAGE_TYPE_UBNT,
 	IMAGE_TYPE_CI,
 	IMAGE_TYPE_CE,
+	IMAGE_TYPE_ZYXEL,
 };
 
 #define DESC_MAX_LENGTH	30


### PR DESCRIPTION
These patches add Zyxel firmware image and flash support, most notably the Zyxel Armor Z2. This is likely to work with other Zyxel devices too.
