### PR TITLE
Add netconsole flash mode support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ OBJ += router_images.o
 OBJ += router_redboot.o
 OBJ += router_tftp_client.o
 OBJ += router_tftp_server.o
+OBJ += router_netconsole.o
 OBJ += router_types.o
 OBJ += socket.o
 AP51_RC = ap51-flash-res

--- a/flash.c
+++ b/flash.c
@@ -135,6 +135,7 @@ static void node_list_maintain(void)
 				telnet_handle_connection(node);
 				break;
 			case FLASH_MODE_TFTP_CLIENT:
+			case FLASH_MODE_NETCONSOLE:
 				/* ignored; handled in handle_udp_packet */
 				break;
 			case FLASH_MODE_UKNOWN:

--- a/flash.h
+++ b/flash.h
@@ -31,6 +31,7 @@ enum flash_mode {
 	FLASH_MODE_REDBOOT,
 	FLASH_MODE_TFTP_SERVER,
 	FLASH_MODE_TFTP_CLIENT,
+	FLASH_MODE_NETCONSOLE,
 };
 
 enum node_status {

--- a/proto.h
+++ b/proto.h
@@ -63,6 +63,8 @@ struct image_state {
 int arp_req_send(const uint8_t *src_mac, const uint8_t *dst_mac,
 		 unsigned int src_ip, unsigned int dst_ip);
 int tftp_init_upload(struct node *node);
+int netconsole_reset(struct node *node);
+int netconsole_init_upload(struct node *node);
 void telnet_handle_connection(struct node *node);
 int telnet_send_cmd(struct node *node, const char *cmd);
 void handle_eth_packet(char *packet_buff, int packet_buff_len);

--- a/router_netconsole.c
+++ b/router_netconsole.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) Antonio Quartulli
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 3 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ *
+ * SPDX-License-Identifier: GPL-3.0+
+ * License-Filename: LICENSES/preferred/GPL-3.0
+ */
+
+#include "router_netconsole.h"
+
+#include <stdint.h>
+
+#include "compat.h"
+#include "flash.h"
+#include "proto.h"
+#include "router_images.h"
+#include "router_types.h"
+
+enum netconsole_state {
+	NETCONSOLE_STATE_WAITING,
+	NETCONSOLE_STATE_STARTED,
+	NETCONSOLE_STATE_DONE,
+	NETCONSOLE_STATE_RESET,
+};
+
+struct netconsole_priv {
+	enum netconsole_state state;
+};
+
+void handle_netconsole_packet(const char *packet_buff, int packet_buff_len,
+			      struct node *node)
+{
+	struct netconsole_priv *priv = node->router_priv;
+
+#define PROMPT_STR "u-boot> "
+#define DONE_STR "DONE!"
+
+//	fprintf(stderr, "received netconsole packet: '%s'\n", packet_buff);
+
+	switch (priv->state) {
+	case NETCONSOLE_STATE_WAITING:
+		if (packet_buff_len < (int)strlen(PROMPT_STR))
+			return;
+
+		if (strncmp(packet_buff, PROMPT_STR, strlen(PROMPT_STR)) != 0)
+			return;
+
+		netconsole_init_upload(node);
+		priv->state = NETCONSOLE_STATE_STARTED;
+
+		break;
+	case NETCONSOLE_STATE_STARTED:
+		/* check if we received the completion message */
+		if (packet_buff_len >= (int)strlen(DONE_STR) &&
+		    strncmp(packet_buff, DONE_STR, strlen(DONE_STR)) == 0) {
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash complete. Waiting for console.\n",
+				node->his_mac_addr[0], node->his_mac_addr[1],
+				node->his_mac_addr[2], node->his_mac_addr[3],
+				node->his_mac_addr[4], node->his_mac_addr[5],
+				node->router_type->desc);
+
+			priv->state = NETCONSOLE_STATE_DONE;
+			break;
+		}
+		/* fall through */
+	case NETCONSOLE_STATE_DONE:
+		if (packet_buff_len < (int)strlen(PROMPT_STR))
+			return;
+
+		if (strncmp(packet_buff, PROMPT_STR, strlen(PROMPT_STR)) != 0)
+			return;
+
+		if (priv->state == NETCONSOLE_STATE_STARTED) {
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: WARNING reflash - finished but no completion message was received.\n",
+				node->his_mac_addr[0], node->his_mac_addr[1],
+				node->his_mac_addr[2], node->his_mac_addr[3],
+				node->his_mac_addr[4], node->his_mac_addr[5],
+				node->router_type->desc);
+		}
+
+		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: rebooting.\n",
+			node->his_mac_addr[0], node->his_mac_addr[1],
+			node->his_mac_addr[2], node->his_mac_addr[3],
+			node->his_mac_addr[4], node->his_mac_addr[5],
+			node->router_type->desc);
+
+		netconsole_reset(node);
+
+		node->status = NODE_STATUS_REBOOTED;
+#if defined(CLEAR_SCREEN)
+		num_nodes_flashed++;
+#endif
+		break;
+	default:
+		break;
+	}
+}

--- a/router_netconsole.h
+++ b/router_netconsole.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Antonio Quartulli
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 3 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ *
+ * SPDX-License-Identifier: GPL-3.0+
+ * License-Filename: LICENSES/preferred/GPL-3.0
+ */
+
+#ifndef __AP51_FLASH_ROUTER_NETCONSOLE_H__
+#define __AP51_FLASH_ROUTER_NETCONSOLE_H__
+
+#define IPPORT_NETCONSOLE 6666
+
+struct node;
+
+void handle_netconsole_packet(const char *packet_buff, int packet_buff_len,
+			      struct node *node);
+
+#endif /* __AP51_FLASH_ROUTER_NETCONSOLE_H__ */

--- a/router_types.c
+++ b/router_types.c
@@ -28,6 +28,7 @@
 #include "router_redboot.h"
 #include "router_tftp_client.h"
 #include "router_tftp_server.h"
+#include "router_netconsole.h"
 
 #if defined(CLEAR_SCREEN)
 #if defined(LINUX) || defined(WIN32)


### PR DESCRIPTION
As explained in the second commit message, this small patchset introduces support for uboot "netconsole". ICMP packets parsing is also required and therefore it is carried along.