### PR TITLE
ap51-flash: add support for Alfa AP121F router

### DIFF
--- a/docs/supported-devices/index.rst
+++ b/docs/supported-devices/index.rst
@@ -16,6 +16,10 @@ quite common amongst a variety of devices.
 Tested
 ======
 
+* Alfa
+
+  - AP121F
+
 * Dlink
 
   - DIR-300 (after installing a reflash-enabled redboot)

--- a/proto.c
+++ b/proto.c
@@ -190,23 +190,12 @@ int tftp_init_upload(struct node *node)
 				     htons(IPPORT_TFTP), data_len);
 }
 
-int netconsole_reset(struct node *node)
-{
-	int data_len;
-
-	/* finished - send reset command to reboot the router */
-	data_len = sprintf(out_tftp_data, "reset\n");
-
-	return tftp_packet_send_data(node, htons(IPPORT_NETCONSOLE),
-				     htons(IPPORT_NETCONSOLE), data_len);
-}
-
 int netconsole_init_upload(struct node *node)
 {
 	int data_len;
 
-	/* TFTP start command */
-	data_len = sprintf(out_tftp_data, "run fw_upg\n");
+	/* TFTP start command and reset (for subsequential reboot) */
+	data_len = sprintf(out_tftp_data, "run fw_upg; reset\n");
 
 	return tftp_packet_send_data(node, htons(IPPORT_NETCONSOLE),
 				     htons(IPPORT_NETCONSOLE), data_len);

--- a/proto.h
+++ b/proto.h
@@ -63,7 +63,6 @@ struct image_state {
 int arp_req_send(const uint8_t *src_mac, const uint8_t *dst_mac,
 		 unsigned int src_ip, unsigned int dst_ip);
 int tftp_init_upload(struct node *node);
-int netconsole_reset(struct node *node);
 int netconsole_init_upload(struct node *node);
 void telnet_handle_connection(struct node *node);
 int telnet_send_cmd(struct node *node, const char *cmd);

--- a/router_images.c
+++ b/router_images.c
@@ -294,6 +294,10 @@ static int uboot_verify(struct router_image *router_image, const char *buff,
 	if (ret)
 		return 0;
 
+	ret = router_image_add_file(router_image, "firmware.bin", size, size, 0);
+	if (ret)
+		return 0;
+
 	router_image->file_size = size;
 	return 1;
 }

--- a/router_netconsole.c
+++ b/router_netconsole.c
@@ -64,42 +64,20 @@ void handle_netconsole_packet(const char *packet_buff, int packet_buff_len,
 		break;
 	case NETCONSOLE_STATE_STARTED:
 		/* check if we received the completion message */
-		if (packet_buff_len >= (int)strlen(DONE_STR) &&
-		    strncmp(packet_buff, DONE_STR, strlen(DONE_STR)) == 0) {
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash complete. Waiting for console.\n",
-				node->his_mac_addr[0], node->his_mac_addr[1],
-				node->his_mac_addr[2], node->his_mac_addr[3],
-				node->his_mac_addr[4], node->his_mac_addr[5],
-				node->router_type->desc);
-
-			priv->state = NETCONSOLE_STATE_DONE;
-			break;
-		}
-		/* fall through */
-	case NETCONSOLE_STATE_DONE:
-		if (packet_buff_len < (int)strlen(PROMPT_STR))
+		if (packet_buff_len < (int)strlen(DONE_STR))
 			return;
 
-		if (strncmp(packet_buff, PROMPT_STR, strlen(PROMPT_STR)) != 0)
+		if (strncmp(packet_buff, DONE_STR, strlen(DONE_STR)) != 0)
 			return;
 
-		if (priv->state == NETCONSOLE_STATE_STARTED) {
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: WARNING reflash - finished but no completion message was received.\n",
-				node->his_mac_addr[0], node->his_mac_addr[1],
-				node->his_mac_addr[2], node->his_mac_addr[3],
-				node->his_mac_addr[4], node->his_mac_addr[5],
-				node->router_type->desc);
-		}
-
-		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: rebooting.\n",
+		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash complete. Rebooting\n",
 			node->his_mac_addr[0], node->his_mac_addr[1],
 			node->his_mac_addr[2], node->his_mac_addr[3],
 			node->his_mac_addr[4], node->his_mac_addr[5],
 			node->router_type->desc);
 
-		netconsole_reset(node);
+		priv->state = NODE_STATUS_REBOOTED;
 
-		node->status = NODE_STATUS_REBOOTED;
 #if defined(CLEAR_SCREEN)
 		num_nodes_flashed++;
 #endif

--- a/router_netconsole.h
+++ b/router_netconsole.h
@@ -26,6 +26,8 @@
 
 struct node;
 
+extern const struct router_type ap121f;
+
 void handle_netconsole_packet(const char *packet_buff, int packet_buff_len,
 			      struct node *node);
 

--- a/router_types.c
+++ b/router_types.c
@@ -57,6 +57,7 @@ static const struct router_type *router_types[] = {
 	&redboot,
 	&ubnt,
 	&zyxel,
+	&ap121f,
 	NULL,
 };
 


### PR DESCRIPTION
This PR adds support for the AP121F platform from Alpha. It works by using the netconsole mechanism to send commands to the router.

The only open issue at the moment is that the final "reset" command is not received by the router console (even though it is captured by wireshark). For this reason the final message printed to screen suggests to reboot the device manually.