### PR TITLE
ap51-flash: Add MAC address whitelist command-line arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ ifeq ($(PLATFORM),LINUX)
   BINARY_SUFFIX =
 else ifeq ($(PLATFORM),WIN32)
   BINARY_SUFFIX = .exe
-  CPPFLAGS += -D_CONSOLE -D_MBCS
+  CPPFLAGS += -D_CONSOLE -D_MBCS -D__USE_MINGW_ANSI_STDIO=1
 
   ifeq ($(origin PKG_CONFIG), undefined)
     PKG_CONFIG = $(CROSS)pkg-config

--- a/commandline.c
+++ b/commandline.c
@@ -4,6 +4,7 @@
 
 #include "commandline.h"
 
+#include <getopt.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -33,15 +34,42 @@ static void usage(const char *prgname)
 
 int main(int argc, char* argv[])
 {
+	bool print_help = false;
+	bool print_version = false;
+	int c;
 	char *iface = NULL;
 	int ret = -1;
 	bool load_embedded = true;
 	const char *progname = "ap51-flash";
+	static struct option long_options[] = {
+		{"help",	no_argument,	0,	'h'},
+		{"version",	no_argument,	0,	'v'},
+		{}
+	};
 
-	if (argc >= 1)
-		progname = argv[0];
+	while ((c = getopt_long(argc, argv, "hv", long_options, NULL)) != -1) {
+		switch (c) {
+		case 'h':
+			print_help = true;
+			ret = 0;
+			break;
+		case 'v':
+			print_version = true;
+			ret = 0;
+			break;
+		case '?':
+			print_help = true;
+			break;
+		}
+	}
 
-	if ((argc == 2) && (strcmp("-v", argv[1]) == 0)) {
+	progname = argv[0];
+	if (print_help) {
+		usage(progname);
+		goto out;
+	}
+
+	if (print_version) {
 #if defined(EMBEDDED_DESC)
 		printf("ap51-flash (%s) [embedded: %s]\n", SOURCE_VERSION,
 		       EMBEDDED_DESC);

--- a/commandline.c
+++ b/commandline.c
@@ -11,6 +11,7 @@
 
 #include "flash.h"
 #include "router_images.h"
+#include "router_types.h"
 #include "socket.h"
 
 #ifndef SOURCE_VERSION
@@ -20,10 +21,11 @@
 static void usage(const char *prgname)
 {
 	fprintf(stderr, "Usage:\n");
-
-	fprintf(stderr, "%s interface image\tflash router with given image\n",
+	fprintf(stderr, "%s interface image\t\t\tflash router with given image\n",
 		prgname);
-	fprintf(stderr, "%s -v\t\t\tprints version information\n", prgname);
+	fprintf(stderr, "%s [-m <MAC>...] interface image\tflash router at given MAC address(es)\n", prgname);
+	fprintf(stderr, "%s -h\t\t\t\t\tshow usage/help\n", prgname);
+	fprintf(stderr, "%s -v\t\t\t\t\tprints version information\n", prgname);
 
 	fprintf(stderr, "\nOne or multiple images of the following type can be specified:\n");
 	router_images_print_desc();
@@ -42,12 +44,13 @@ int main(int argc, char* argv[])
 	bool load_embedded = true;
 	const char *progname = "ap51-flash";
 	static struct option long_options[] = {
-		{"help",	no_argument,	0,	'h'},
-		{"version",	no_argument,	0,	'v'},
+		{"help",	no_argument,		0,	'h'},
+		{"version",	no_argument,		0,	'v'},
+		{"mac",		required_argument,	0,	'm'},
 		{}
 	};
 
-	while ((c = getopt_long(argc, argv, "hv", long_options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "hvm:", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'h':
 			print_help = true;
@@ -57,6 +60,10 @@ int main(int argc, char* argv[])
 			print_version = true;
 			ret = 0;
 			break;
+		case 'm':
+			if (mac_whitelist_add(optarg) == 0)
+				break;
+			/* fall-through */
 		case '?':
 			print_help = true;
 			break;
@@ -76,8 +83,11 @@ int main(int argc, char* argv[])
 #else
 		printf("ap51-flash (%s)\n", SOURCE_VERSION);
 #endif
-		return 0;
+		goto out;
 	}
+
+	argc -= optind;
+	argv += optind;
 
 	if (argc < 2) {
 		fprintf(stderr, "Error - no interface specified\n");
@@ -85,14 +95,14 @@ int main(int argc, char* argv[])
 		goto out;
 	}
 
-	if (strlen(argv[1]) < 3)
-		iface = socket_find_iface_by_index(argv[1]);
+	if (strlen(argv[0]) < 3)
+		iface = socket_find_iface_by_index(argv[0]);
 
 	if (!iface)
-		iface = argv[1];
+		iface = argv[0];
 
-	argc -= 2;
-	argv += 2;
+	argc -= 1;
+	argv += 1;
 
 	router_images_init();
 

--- a/router_types.h
+++ b/router_types.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "ap51-flash.h"
+#include "compat.h"
 
 struct node;
 
@@ -34,10 +35,16 @@ struct router_type {
 	int priv_size;
 };
 
+struct mac_whitelist_entry {
+	uint8_t mac[ETH_ALEN];
+	struct mac_whitelist_entry *next;
+};
+
 int router_types_init(void);
 void router_types_detect_pre(const uint8_t *our_mac);
 int router_types_detect_main(struct node *node, const char *packet_buff,
 			     int packet_buff_len);
+int mac_whitelist_add(const char *macstr);
 
 extern int router_types_priv_size;
 


### PR DESCRIPTION
Adds "-m <mac>" command-line argument to whitelist a specific MAC address for flashing. Any device that does not match the given MAC address will be ignored.

This is useful in environments where there are many devices on the network and you do not want to accidentally flash the wrong device, if it happens to be booting while ap51-flash is running.