### PR TITLE
ap51-flash: allow starting ap51-flash without specifying image name

### DIFF
--- a/commandline.c
+++ b/commandline.c
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
 	argc -= optind;
 	argv += optind;
 
-	if (argc < 2) {
+	if (argc < 1) {
 		fprintf(stderr, "Error - no interface specified\n");
 		usage(progname);
 		goto out;


### PR DESCRIPTION
Fixes: 363933b9f2b47a9604835fd5fefa6591c80a68bd

Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>
