### PR TITLE
Parse multiple RTNL interface packets

### DIFF
--- a/commandline.c
+++ b/commandline.c
@@ -95,9 +95,7 @@ int main(int argc, char* argv[])
 		goto out;
 	}
 
-	if (strlen(argv[0]) < 3)
-		iface = socket_find_iface_by_index(argv[0]);
-
+	iface = socket_find_iface_by_index(argv[0]);
 	if (!iface)
 		iface = argv[0];
 

--- a/socket.c
+++ b/socket.c
@@ -158,10 +158,10 @@ char *socket_find_iface_by_index(const char *iface_number)
 			if (rta_payload <= 0)
 				continue;
 
-			rta_data[rta_payload - 1] = '\0';
-
 			if (rta->rta_type != IFLA_IFNAME)
 				continue;
+
+			rta_data[rta_payload - 1] = '\0';
 
 			if (if_count == (unsigned int)if_num) {
 				iface = strdup(rta_data);
@@ -248,10 +248,10 @@ void socket_print_all_ifaces(void)
 			if (rta_payload <= 0)
 				continue;
 
-			rta_data[rta_payload - 1] = '\0';
-
 			if (rta->rta_type != IFLA_IFNAME)
 				continue;
+
+			rta_data[rta_payload - 1] = '\0';
 
 			fprintf(stderr, "%i: %s\n", if_count, rta_data);
 			fprintf(stderr, "\t(No description available)\n");

--- a/socket.c
+++ b/socket.c
@@ -278,7 +278,7 @@ out:
 		i++;
 		fprintf(stderr, "\n%i: %s\n", i, dev->name);
 
-		if (!dev->description) {
+		if (!dev->description || strlen(dev->description) == 0) {
 			fprintf(stderr, "\t(No description available)\n");
 			continue;
 		}

--- a/socket.c
+++ b/socket.c
@@ -193,6 +193,9 @@ out:
 
 	i = 0;
 	slist_for_each (dev, alldevs) {
+		if (dev->flags & PCAP_IF_LOOPBACK)
+			continue;
+
 		i++;
 
 		if (if_num != i)
@@ -279,6 +282,9 @@ out:
 
 	i = 0;
 	slist_for_each (dev, alldevs) {
+		if (dev->flags & PCAP_IF_LOOPBACK)
+			continue;
+
 		i++;
 		fprintf(stderr, "\n%i: %s\n", i, dev->name);
 

--- a/socket.c
+++ b/socket.c
@@ -145,6 +145,9 @@ char *socket_find_iface_by_index(const char *iface_number)
 		rta = IFLA_RTA(ifinfomsg);
 		attr_len = IFLA_PAYLOAD(nh);
 
+		if (ifinfomsg->ifi_type != ARPHRD_ETHER)
+			continue;
+
 		for (; RTA_OK(rta, attr_len); rta = RTA_NEXT(rta, attr_len)) {
 			char *rta_data = RTA_DATA(rta);
 			size_t rta_payload = RTA_PAYLOAD(rta);
@@ -155,9 +158,6 @@ char *socket_find_iface_by_index(const char *iface_number)
 			rta_data[rta_payload - 1] = '\0';
 
 			if (rta->rta_type != IFLA_IFNAME)
-				continue;
-
-			if (strncmp(rta_data, "lo", rta_payload) == 0)
 				continue;
 
 			if (if_count == (unsigned int)if_num) {
@@ -235,6 +235,9 @@ void socket_print_all_ifaces(void)
 		rta = IFLA_RTA(ifinfomsg);
 		attr_len = IFLA_PAYLOAD(nh);
 
+		if (ifinfomsg->ifi_type != ARPHRD_ETHER)
+			continue;
+
 		for (; RTA_OK(rta, attr_len); rta = RTA_NEXT(rta, attr_len)) {
 			char *rta_data = RTA_DATA(rta);
 			size_t rta_payload = RTA_PAYLOAD(rta);
@@ -245,9 +248,6 @@ void socket_print_all_ifaces(void)
 			rta_data[rta_payload - 1] = '\0';
 
 			if (rta->rta_type != IFLA_IFNAME)
-				continue;
-
-			if (strncmp(rta_data, "lo", rta_payload) == 0)
 				continue;
 
 			fprintf(stderr, "%i: %s\n", if_count, rta_data);

--- a/socket.c
+++ b/socket.c
@@ -131,7 +131,6 @@ static int socket_dump_ifaces(enum listdump_action (*dump)(const char *name,
 	struct nlmsghdr *resp = NULL;
 	struct ifinfomsg *ifinfomsg;
 	enum listdump_action action;
-	unsigned int if_count = 0;
 	unsigned int len = 0;
 	struct nlmsghdr *nh;
 	struct rtattr *rta;
@@ -170,8 +169,7 @@ static int socket_dump_ifaces(enum listdump_action (*dump)(const char *name,
 
 			rta_data[rta_payload - 1] = '\0';
 
-			if_count++;
-			action = dump(rta_data, if_count, NULL, arg);
+			action = dump(rta_data, ifinfomsg->ifi_index, NULL, arg);
 		}
 
 		if (action == LISTDUMP_STOP)

--- a/socket.c
+++ b/socket.c
@@ -80,9 +80,12 @@ peek_retry:
 	if (!*nh)
 		goto close_sock;
 
+recv_retry:
 	rlen = recv(sock, *nh, rlen, 0);
-
 	if (rlen < 0) {
+		if (errno == EINTR)
+			goto recv_retry;
+
 		fprintf(stderr,
 			"Error - unable to receive netlink request: %s\n",
 			strerror(errno));

--- a/socket.c
+++ b/socket.c
@@ -254,9 +254,13 @@ char *socket_find_iface_by_index(const char *iface_number)
 	struct socket_find_iface_by_index_arg find_arg = {
 		.name = NULL,
 	};
+	char *endptr;
 	long if_num;
 
-	if_num = strtol(iface_number, NULL, 10);
+	if_num = strtol(iface_number, &endptr, 10);
+	if (!endptr || iface_number == endptr || *endptr != '\0')
+		return NULL;
+
 	if (if_num < 1)
 		return NULL;
 


### PR DESCRIPTION
The RTM_GETLINK response can be splitted in multiple packets. The first packet has usually the "lo" interface (ignored by ap51-flash) and maybe another interface. The ap51-flash will then report in the interface list something like:
    
      2: enp8s0
              (No description available)
    
But there is often one or more other packets with more RTNL messages. By also parsing them, the list of interfaces will then look more like:
    
      2: enp8s0
              (No description available)
    
      3: wwp0s26u1u1i6
              (No description available)
    
      4: wlp2s0
              (No description available)
    
      8: bat0
              (No description available)