### PR TITLE
Test WinPcap and Npcap SDK builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,34 @@ matrix:
       - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
       - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-winpcap.exe
+    # windows cross-compiler (Npcap)
+    - os: linux
+      env:
+      - MXE_CPU=i686
+      - PATH="/usr/lib/mxe/usr/bin/:$PATH"
+      - WINPCAP_LDLIBS="-Lnpcap-sdk/Lib/ -lwpcap"
+      - WINPCAP_CFLAGS="-Inpcap-sdk/Include/"
+      addons:
+        apt:
+          sources:
+          - sourceline: 'deb http://pkg.mxe.cc/repos/apt/ xenial main'
+            key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC6BF758A33A3A276'
+          packages:
+          - curl
+          - unzip
+          - mxe-i686-w64-mingw32.static-gcc
+          - mxe-i686-w64-mingw32.static-pkgconf
+      before_script:
+      - curl https://nmap.org/npcap/dist/npcap-sdk-1.04.zip -o npcap-sdk-1.04.zip
+      - unzip npcap-sdk-1.04.zip -d npcap-sdk
+      - dd if=/dev/urandom of=test.img count=10000 bs=1024
+      script:
+      - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN -DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
+      - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-npcap.exe
     # musl static cross build
     - os: linux
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 
 matrix:
   include:
-    # windows cross-compiler
+    # windows cross-compiler (MXE-only)
     - os: linux
       env:
       - MXE_CPU=i686
@@ -48,7 +48,35 @@ matrix:
       - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN -DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
       - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
-      - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686.exe
+      - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-static.exe
+    # windows cross-compiler (WinPCAP)
+    - os: linux
+      env:
+      - MXE_CPU=i686
+      - PATH="/usr/lib/mxe/usr/bin/:$PATH"
+      - WINPCAP_LDLIBS="-LWpdPack/Lib/ -lwpcap"
+      - WINPCAP_CFLAGS="-IWpdPack/Include/"
+      addons:
+        apt:
+          sources:
+          - sourceline: 'deb http://pkg.mxe.cc/repos/apt/ xenial main'
+            key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC6BF758A33A3A276'
+          packages:
+          - curl
+          - unzip
+          - mxe-i686-w64-mingw32.static-gcc
+          - mxe-i686-w64-mingw32.static-pkgconf
+      before_script:
+      - curl https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip -o WpdPack_4_1_2.zip
+      - unzip WpdPack_4_1_2.zip
+      - dd if=/dev/urandom of=test.img count=10000 bs=1024
+      script:
+      - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN -DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
+      - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-winpcap.exe
     # musl static cross build
     - os: linux
       env:

--- a/compat.h
+++ b/compat.h
@@ -46,7 +46,6 @@
 #define USE_PCAP 1
 
 #include <pcap.h>
-#include <Win32-Extensions.h>
 
 #define ntohs(x) __swab16(x)
 #define htons(x) __swab16(x)


### PR DESCRIPTION
Some users still use the old WinPCAP 4.1.2 SDK to build these binaries. This has the benefit that the binaries are smaller and will also support npcap's WinPCAP compatibility layer.

Other users switched to Npcap as modern replacement of the WinPCAP SDK. While the redistribution license is rather problematic, it is the current only viable way to run it on modern Windows with driver signing.