### PR TITLE
Add support for modern Npcap DLLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,11 @@
 *.o
 
 /ap51-flash
-/ap51-flash.exe
+/ap51-flash*.exe
 /ap51-flash-osx
 /ap51-flash-res
 /docs/_build/
+
+/npcap-sdk/
+/WpdPack/
+/test.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
       before_script:
       - curl https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip -o WpdPack_4_1_2.zip
       - unzip WpdPack_4_1_2.zip
+      - rm -f WpdPack_4_1_2.zip
       - dd if=/dev/urandom of=test.img count=10000 bs=1024
       script:
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
@@ -97,6 +98,7 @@ matrix:
       before_script:
       - curl https://nmap.org/npcap/dist/npcap-sdk-1.04.zip -o npcap-sdk-1.04.zip
       - unzip npcap-sdk-1.04.zip -d npcap-sdk
+      - rm -f npcap-sdk-1.04.zip
       - dd if=/dev/urandom of=test.img count=10000 bs=1024
       script:
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
@@ -125,6 +127,7 @@ matrix:
       before_script:
       - curl https://nmap.org/npcap/dist/npcap-sdk-1.04.zip -o npcap-sdk-1.04.zip
       - unzip npcap-sdk-1.04.zip -d npcap-sdk
+      - rm -f npcap-sdk-1.04.zip
       - mkdir -p npcap-sdk/Lib-delayed
       - |
         cat > npcap-sdk/Lib-delayed/wpcap.def <<EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
       - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
       - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-winpcap.exe
-    # windows cross-compiler (Npcap)
+    # windows cross-compiler (Npcap WinPcap mode)
     - os: linux
       env:
       - MXE_CPU=i686
@@ -97,6 +97,48 @@ matrix:
       before_script:
       - curl https://nmap.org/npcap/dist/npcap-sdk-1.04.zip -o npcap-sdk-1.04.zip
       - unzip npcap-sdk-1.04.zip -d npcap-sdk
+      - dd if=/dev/urandom of=test.img count=10000 bs=1024
+      script:
+      - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN -DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
+      - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
+      - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-winpcap.exe
+    # windows cross-compiler (Npcap modern mode)
+    - os: linux
+      env:
+      - MXE_CPU=i686
+      - PATH="/usr/lib/mxe/usr/bin/:$PATH"
+      - WINPCAP_LDLIBS="-Lnpcap-sdk/Lib-delayed/ -lwpcap"
+      - WINPCAP_CFLAGS="-Inpcap-sdk/Include/ -DNPCAP"
+      addons:
+        apt:
+          sources:
+          - sourceline: 'deb http://pkg.mxe.cc/repos/apt/ xenial main'
+            key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC6BF758A33A3A276'
+          packages:
+          - curl
+          - unzip
+          - mxe-i686-w64-mingw32.static-gcc
+          - mxe-i686-w64-mingw32.static-pkgconf
+      before_script:
+      - curl https://nmap.org/npcap/dist/npcap-sdk-1.04.zip -o npcap-sdk-1.04.zip
+      - unzip npcap-sdk-1.04.zip -d npcap-sdk
+      - mkdir -p npcap-sdk/Lib-delayed
+      - |
+        cat > npcap-sdk/Lib-delayed/wpcap.def <<EOF
+        LIBRARY "wpcap.dll"
+        EXPORTS
+        pcap_close
+        pcap_findalldevs
+        pcap_freealldevs
+        pcap_next
+        pcap_open_live
+        pcap_sendpacket
+        pcap_setmintocopy
+        EOF
+      - "${MXE_CPU}-w64-mingw32.static-dlltool --output-delaylib npcap-sdk/Lib-delayed/wpcap.lib --def npcap-sdk/Lib-delayed/wpcap.def"
       - dd if=/dev/urandom of=test.img count=10000 bs=1024
       script:
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe


### PR DESCRIPTION
The modern Npcap DLLs are the only ones which are installed by default by Npcap. The WinPCAP compatibility DLLs are only installed as optional feature.

Unfortunately, the modern Npcap DLLs are in a Windows subdirectory which is not searched by default. The program must instead take care of selecting the new path and thus load the libraries in a delayed fashion.