### PR TITLE
ap51-flash: Test mingw64-w64 crosscompiler for Debian/Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,6 +150,44 @@ matrix:
       - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe
       - make clean V=s && make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" EMBED_CI="test.img" ap51-flash.exe
       - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="${MXE_CPU}-w64-mingw32.static-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-npcap.exe
+    # Debian mingw-w64 windows cross-compiler (Npcap modern mode)
+    - os: linux
+      env:
+      - WINPCAP_LDLIBS="-Lnpcap-sdk/Lib-delayed/ -lwpcap"
+      - WINPCAP_CFLAGS="-Inpcap-sdk/Include/ -DNPCAP"
+      addons:
+        apt:
+          packages:
+          - curl
+          - unzip
+          - mingw-w64-tools
+          - gcc-mingw-w64
+      before_script:
+      - curl https://nmap.org/npcap/dist/npcap-sdk-1.04.zip -o npcap-sdk-1.04.zip
+      - unzip npcap-sdk-1.04.zip -d npcap-sdk
+      - rm -f npcap-sdk-1.04.zip
+      - mkdir -p npcap-sdk/Lib-delayed
+      - |
+        cat > npcap-sdk/Lib-delayed/wpcap.def <<EOF
+        LIBRARY "wpcap.dll"
+        EXPORTS
+        pcap_close
+        pcap_findalldevs
+        pcap_freealldevs
+        pcap_next
+        pcap_open_live
+        pcap_sendpacket
+        pcap_setmintocopy
+        EOF
+      - "i686-w64-mingw32-dlltool --output-delaylib npcap-sdk/Lib-delayed/wpcap.lib --def npcap-sdk/Lib-delayed/wpcap.def"
+      - dd if=/dev/urandom of=test.img count=10000 bs=1024
+      script:
+      - make clean V=s && make V=s CROSS="i686-w64-mingw32-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN" make V=s CROSS="i686-w64-mingw32-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DCLEAR_SCREEN -DDEBUG" make V=s CROSS="i686-w64-mingw32-" ap51-flash.exe
+      - make clean V=s && CPPFLAGS="-DDEBUG" make V=s CROSS="i686-w64-mingw32-" ap51-flash.exe
+      - make clean V=s && make V=s CROSS="i686-w64-mingw32-" EMBED_CI="test.img" ap51-flash.exe
+      - make clean V=s && CFLAGS="-flto -O2" make V=s CROSS="i686-w64-mingw32-" ap51-flash.exe && mv ap51-flash.exe ap51-flash-i686-npcap.exe
     # musl static cross build
     - os: linux
       env:


### PR DESCRIPTION
Some users prefer to use the gcc-mingw-w64 package to build the windows binary instead of MXE. It has the benefit that it doesn't any external apt source to cross compile the sources for windows.