### PR TITLE
ap51-flash: drop 'router' device description

### DIFF
--- a/commandline.c
+++ b/commandline.c
@@ -21,9 +21,9 @@
 static void usage(const char *prgname)
 {
 	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "%s interface image\t\t\tflash router with given image\n",
+	fprintf(stderr, "%s interface image\t\t\tflash device with given image\n",
 		prgname);
-	fprintf(stderr, "%s [-m <MAC>...] interface image\tflash router at given MAC address(es)\n", prgname);
+	fprintf(stderr, "%s [-m <MAC>...] interface image\tflash device at given MAC address(es)\n", prgname);
 	fprintf(stderr, "%s -h\t\t\t\t\tshow usage/help\n", prgname);
 	fprintf(stderr, "%s -v\t\t\t\t\tprints version information\n", prgname);
 

--- a/flash.c
+++ b/flash.c
@@ -105,7 +105,7 @@ static void node_list_maintain(void)
 			if (ret == 0)
 				break;
 
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash complete. Device ready to unplug.\n",
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flash complete. Device ready to unplug.\n",
 				node->his_mac_addr[0], node->his_mac_addr[1],
 				node->his_mac_addr[2], node->his_mac_addr[3],
 				node->his_mac_addr[4], node->his_mac_addr[5],

--- a/proto.c
+++ b/proto.c
@@ -240,7 +240,7 @@ static void handle_arp_packet(const char *packet_buff, int packet_buff_len,
 	case NODE_STATUS_RESET_SENT:
 	case NODE_STATUS_FINISHED:
 		if (node->flash_mode != FLASH_MODE_NETCONSOLE) {
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash complete. Device ready to unplug.\n",
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flash complete. Device ready to unplug.\n",
 				node->his_mac_addr[0], node->his_mac_addr[1],
 				node->his_mac_addr[2], node->his_mac_addr[3],
 				node->his_mac_addr[4], node->his_mac_addr[5],
@@ -318,7 +318,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 			file_info = router_image_get_file(node->router_type,
 							  file_name);
 			if (!file_info) {
-				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: tftp client asks for '%s' - file not found ...\n",
+				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: tftp client asks for '%s' - file not found ...\n",
 					node->his_mac_addr[0],
 					node->his_mac_addr[1],
 					node->his_mac_addr[2],
@@ -336,7 +336,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 				node->status = NODE_STATUS_FLASHING;
 			}
 
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: tftp client asks for '%s', serving %s portion of: %s (%i blocks) ...\n",
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: tftp client asks for '%s', serving %s portion of: %s (%i blocks) ...\n",
 				node->his_mac_addr[0], node->his_mac_addr[1],
 				node->his_mac_addr[2], node->his_mac_addr[3],
 				node->his_mac_addr[4], node->his_mac_addr[5],
@@ -373,7 +373,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 										FLASH_PAGE_SIZE) * FLASH_PAGE_SIZE;
 				node->image_state.offset = 0;
 
-				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: connection to tftp server established - uploading %i blocks ...\n",
+				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: connection to tftp server established - uploading %i blocks ...\n",
 					node->his_mac_addr[0],
 					node->his_mac_addr[1],
 					node->his_mac_addr[2],
@@ -388,7 +388,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 			node->image_state.block_sent = 0;
 		} else if (block != node->image_state.block_sent) {
 			if (block < node->image_state.block_sent)
-				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: tftp repeat block %d, last received ack: %d\n",
+				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: tftp repeat block %d, last received ack: %d\n",
 					node->his_mac_addr[0],
 					node->his_mac_addr[1],
 					node->his_mac_addr[2],
@@ -398,7 +398,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 					node->router_type->desc, block + 1,
 					node->image_state.block_acked);
 			else
-				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: tftp acks unsent block %d (last sent block: %d)\n",
+				fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: tftp acks unsent block %d (last sent block: %d)\n",
 					node->his_mac_addr[0],
 					node->his_mac_addr[1],
 					node->his_mac_addr[2],
@@ -424,7 +424,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 					case FLASH_MODE_TFTP_SERVER:
 					case FLASH_MODE_TFTP_CLIENT:
 					case FLASH_MODE_NETCONSOLE:
-						fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: image successfully transmitted - writing image to flash ...\n",
+						fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: image successfully transmitted - writing image to flash ...\n",
 							node->his_mac_addr[0],
 							node->his_mac_addr[1],
 							node->his_mac_addr[2],
@@ -478,14 +478,14 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 	/* TFTP error */
 	case 5:
 		if ((block == 2) && (htons(udphdr->len) - sizeof(struct udphdr) > 4))
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: received TFTP error: %s\n",
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: received TFTP error: %s\n",
 				node->his_mac_addr[0], node->his_mac_addr[1],
 				node->his_mac_addr[2], node->his_mac_addr[3],
 				node->his_mac_addr[4], node->his_mac_addr[5],
 				node->router_type->desc,
 				(packet_buff + sizeof(struct udphdr) + 4));
 		else
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: received TFTP error code: %d\n",
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: received TFTP error code: %d\n",
 				node->his_mac_addr[0], node->his_mac_addr[1],
 				node->his_mac_addr[2], node->his_mac_addr[3],
 				node->his_mac_addr[4], node->his_mac_addr[5],
@@ -493,7 +493,7 @@ static void handle_udp_packet(const char *packet_buff, int packet_buff_len,
 
 		break;
 	default:
-		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: unexpected TFTP opcode: %d\n",
+		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: unexpected TFTP opcode: %d\n",
 			node->his_mac_addr[0], node->his_mac_addr[1],
 			node->his_mac_addr[2], node->his_mac_addr[3],
 			node->his_mac_addr[4], node->his_mac_addr[5],

--- a/router_netconsole.c
+++ b/router_netconsole.c
@@ -119,7 +119,7 @@ void handle_netconsole_packet(const char *packet_buff, int packet_buff_len,
 		if (strncmp(packet_buff, DONE_STR, strlen(DONE_STR)) != 0)
 			return;
 
-		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash complete. Rebooting\n",
+		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flash complete. Rebooting\n",
 			node->his_mac_addr[0], node->his_mac_addr[1],
 			node->his_mac_addr[2], node->his_mac_addr[3],
 			node->his_mac_addr[4], node->his_mac_addr[5],

--- a/router_redboot.c
+++ b/router_redboot.c
@@ -66,7 +66,7 @@ static int redboot_8mb_detect(struct node *node)
 		goto out;
 
 #if defined(DEBUG)
-	fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash size of 8 MB was detected ...\n",
+	fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flash size of 8 MB was detected ...\n",
 		node->his_mac_addr[0], node->his_mac_addr[1],
 		node->his_mac_addr[2], node->his_mac_addr[3],
 		node->his_mac_addr[4], node->his_mac_addr[5],
@@ -87,7 +87,7 @@ static int redboot_4mb_detect(struct node (*node)__attribute__((unused)))
 {
 	/* default redboot type */
 #if defined(DEBUG)
-	fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flash size of 4 MB was detected (default) ...\n",
+	fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flash size of 4 MB was detected (default) ...\n",
 		node->his_mac_addr[0], node->his_mac_addr[1],
 		node->his_mac_addr[2], node->his_mac_addr[3],
 		node->his_mac_addr[4], node->his_mac_addr[5],
@@ -164,7 +164,7 @@ void redboot_main(struct node *node, const char *telnet_msg)
 							FLASH_PAGE_SIZE) * FLASH_PAGE_SIZE;
 
 		if (redboot_priv->redboot_type->flash_size < req_flash_size) {
-			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: image size '%s' of 0x%08lx exceeds router capacity: 0x%08lx\n",
+			fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: %s: image size '%s' of 0x%08lx exceeds device capacity: 0x%08lx\n",
 				node->his_mac_addr[0], node->his_mac_addr[1],
 				node->his_mac_addr[2], node->his_mac_addr[3],
 				node->his_mac_addr[4], node->his_mac_addr[5],
@@ -179,7 +179,7 @@ void redboot_main(struct node *node, const char *telnet_msg)
 			((unsigned char *)&node->our_ip_addr)[0], ((unsigned char *)&node->our_ip_addr)[1],
 			((unsigned char *)&node->our_ip_addr)[2], ((unsigned char *)&node->our_ip_addr)[3]);
 
-		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: setting IP address ...\n",
+		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s: setting IP address ...\n",
 		       node->his_mac_addr[0], node->his_mac_addr[1],
 		       node->his_mac_addr[2], node->his_mac_addr[3],
 		       node->his_mac_addr[4], node->his_mac_addr[5],
@@ -205,7 +205,7 @@ void redboot_main(struct node *node, const char *telnet_msg)
 			goto redboot_failure;
 		}
 
-		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: initializing partitions ...\n",
+		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s: initializing partitions ...\n",
 		       node->his_mac_addr[0], node->his_mac_addr[1],
 		       node->his_mac_addr[2], node->his_mac_addr[3],
 		       node->his_mac_addr[4], node->his_mac_addr[5],
@@ -223,7 +223,7 @@ void redboot_main(struct node *node, const char *telnet_msg)
 			redboot_priv->redboot_type->kernel_load_addr,
 			redboot_priv->redboot_type->kernel_load_addr);
 
-		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flashing kernel ...\n",
+		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flashing kernel ...\n",
 		       node->his_mac_addr[0], node->his_mac_addr[1],
 		       node->his_mac_addr[2], node->his_mac_addr[3],
 		       node->his_mac_addr[4], node->his_mac_addr[5],
@@ -251,7 +251,7 @@ void redboot_main(struct node *node, const char *telnet_msg)
 			redboot_priv->redboot_type->flash_addr + file_info->file_fsize,
 			redboot_priv->redboot_type->flash_size - file_info->file_fsize);
 
-		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: flashing rootfs ...\n",
+		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s: flashing rootfs ...\n",
 		       node->his_mac_addr[0], node->his_mac_addr[1],
 		       node->his_mac_addr[2], node->his_mac_addr[3],
 		       node->his_mac_addr[4], node->his_mac_addr[5],
@@ -261,7 +261,7 @@ void redboot_main(struct node *node, const char *telnet_msg)
 		redboot_priv->redboot_state = REDBOOT_STATE_FL_ROOTFS;
 		break;
 	case REDBOOT_STATE_FL_ROOTFS:
-		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s router: setting boot_script_data ...\n",
+		printf("[%02x:%02x:%02x:%02x:%02x:%02x]: %s: setting boot_script_data ...\n",
 		       node->his_mac_addr[0], node->his_mac_addr[1],
 		       node->his_mac_addr[2], node->his_mac_addr[3],
 		       node->his_mac_addr[4], node->his_mac_addr[5],

--- a/router_types.c
+++ b/router_types.c
@@ -220,7 +220,7 @@ int router_types_detect_main(struct node *node, const char *packet_buff,
 		ret = 1;
 #endif
 
-		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: type '%s router' detected\n",
+		fprintf(stderr, "[%02x:%02x:%02x:%02x:%02x:%02x]: device type '%s' detected\n",
 			node->his_mac_addr[0], node->his_mac_addr[1],
 			node->his_mac_addr[2], node->his_mac_addr[3],
 			node->his_mac_addr[4], node->his_mac_addr[5],


### PR DESCRIPTION
The ap51-flash device detection & flash output mentions the word
"router" a few times which may be misleading. For example:

[XX:XX:XX:XX:XX:XX]: type 'PAX1800 router' detected

Instead of labeling every detected a device with "router" this
patch either omits the label or changes it to "device".

Example:
[XX:XX:XX:XX:XX:XX]: device type 'PAX1800' detected

Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>
