### PR TITLE
ap51-flash: Release 2022.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 .. SPDX-FileCopyrightText: Sven Eckelmann <sven@narfation.org>
 
 
+2022.1 (2022-12-31)
+===================
+
+* Refactoring of tftp-server code
+* added support for:
+
+  - Plasma Cloud PAX1800 v2
+
+
 2022.0 (2022-03-16)
 ===================
 

--- a/commandline.c
+++ b/commandline.c
@@ -15,7 +15,7 @@
 #include "socket.h"
 
 #ifndef SOURCE_VERSION
-#define SOURCE_VERSION "2022.0+"
+#define SOURCE_VERSION "2022.1"
 #endif
 
 static void usage(const char *prgname)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,9 +15,9 @@ copyright = u'ap51-flash Team'
 author = u'ap51-flash Team'
 
 # The short X.Y version
-version = u'2022.0+'
+version = u'2022.1'
 # The full version, including alpha/beta/rc tags
-release = u'2022.0+'
+release = u'2022.1'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
* Refactoring of tftp-server code
* added support for:
   - Plasma Cloud PAX1800 v2
