### PR TITLE
ap51-flash: netconsole: Split private and node state

### DIFF
--- a/router_netconsole.c
+++ b/router_netconsole.c
@@ -125,7 +125,8 @@ void handle_netconsole_packet(const char *packet_buff, int packet_buff_len,
 			node->his_mac_addr[4], node->his_mac_addr[5],
 			node->router_type->desc);
 
-		priv->state = NODE_STATUS_REBOOTED;
+		priv->state = NETCONSOLE_STATE_DONE;
+		node->status = NODE_STATUS_REBOOTED;
 
 #if defined(CLEAR_SCREEN)
 		num_nodes_flashed++;


### PR DESCRIPTION
The netconsole code has its own internal state which is basically an embedded state machine in the global node state machine. While this code was refactored to simplify it, the code to switch the node state was accidentally dropped and instead it was tried to save the node state in the netconsole specific state.

This had no effect until now because the NODE_STATUS_REBOOTED (6) is outside the possible states for the netconsole. And the code handled this as "nothing to do".

Fixes: 7a4ef891a229 ("ap51-flash: netconsole - concatenate reset command to reflash")