### PR TITLE
ap51-flash: Ignore overlong generated filenames

### DIFF
--- a/router_images.c
+++ b/router_images.c
@@ -114,7 +114,7 @@ struct file_info *router_image_get_file(struct router_type *router_type,
 	char file_name_buff[FILE_NAME_MAX_LENGTH];
 
 	if (strcmp(file_name, fwupgradecfg) == 0) {
-		snprintf(file_name_buff, FILE_NAME_MAX_LENGTH - 1, "%s-%s",
+		snprintf(file_name_buff, FILE_NAME_MAX_LENGTH, "%s-%s",
 			 file_name,
 			 router_type->image_desc ? router_type->image_desc : router_type->desc);
 		file_info = _router_image_get_file(&router_type->image->file_list,
@@ -122,7 +122,7 @@ struct file_info *router_image_get_file(struct router_type *router_type,
 	}
 
 	if (strcmp(file_name, fwupgradecfgsig) == 0) {
-		snprintf(file_name_buff, FILE_NAME_MAX_LENGTH - 1, "%s-%s.sig",
+		snprintf(file_name_buff, FILE_NAME_MAX_LENGTH, "%s-%s.sig",
 			 fwupgradecfg,
 			 router_type->image_desc ? router_type->image_desc : router_type->desc);
 		file_info = _router_image_get_file(&router_type->image->file_list,

--- a/router_images.c
+++ b/router_images.c
@@ -107,24 +107,40 @@ static struct file_info *_router_image_get_file(struct list_head *file_list,
 	return NULL;
 }
 
+static const char *router_get_file_postfix(const struct router_type *router_type)
+{
+	if (router_type->image_desc)
+		return router_type->image_desc;
+
+	return router_type->desc;
+}
+
 struct file_info *router_image_get_file(struct router_type *router_type,
 					const char *file_name)
 {
 	struct file_info *file_info = NULL;
 	char file_name_buff[FILE_NAME_MAX_LENGTH];
+	int ret;
 
 	if (strcmp(file_name, fwupgradecfg) == 0) {
-		snprintf(file_name_buff, FILE_NAME_MAX_LENGTH, "%s-%s",
-			 file_name,
-			 router_type->image_desc ? router_type->image_desc : router_type->desc);
+		ret = snprintf(file_name_buff, FILE_NAME_MAX_LENGTH, "%s-%s",
+			       file_name,
+			       router_get_file_postfix(router_type));
+
+		if (ret >= FILE_NAME_MAX_LENGTH)
+			return NULL;
+
 		file_info = _router_image_get_file(&router_type->image->file_list,
 						   file_name_buff);
 	}
 
 	if (strcmp(file_name, fwupgradecfgsig) == 0) {
-		snprintf(file_name_buff, FILE_NAME_MAX_LENGTH, "%s-%s.sig",
-			 fwupgradecfg,
-			 router_type->image_desc ? router_type->image_desc : router_type->desc);
+		ret = snprintf(file_name_buff, FILE_NAME_MAX_LENGTH,
+			       "%s-%s.sig", fwupgradecfg,
+			       router_get_file_postfix(router_type));
+		if (ret >= FILE_NAME_MAX_LENGTH)
+			return NULL;
+
 		file_info = _router_image_get_file(&router_type->image->file_list,
 						   file_name_buff);
 	}


### PR DESCRIPTION
For "COMBINED" CE01 images for multiple devices, the standard filenames "fwupgrade.cfg" and "fwupgrade.cfg.sig" are mapped to device specific names. This could for example be:

* OM2P: fwupgrade.cfg.sig -> fwupgrade.cfg-OM2P.sig
* A40: fwupgrade.cfg -> fwupgrade.cfg-A60

But for really long router type names, it doesn't work. A filename in the CE01 index can only be 32 characters long. So the router_type "REALLYLARGEDEVNAME" would try to calculate the fwupgrade.cfg.sig name "fwupgrade.cfg-REALLYLARGEDEVNAME.sig". But in the buffer, there is only enough space for "fwupgrade.cfg-REALLYLARGEDEVNAME". Which is unfortunately not the name of the fwupgrade.cfg.sig but for the "fwupgrade.cfg.

Just ignore the generated names in case they couldn't be written correctly in the buffer (completely).