### PR TITLE
ap51-flash: add support for Plasma Cloud PAX1800-Lite

### DIFF
--- a/docs/supported-devices/index.rst
+++ b/docs/supported-devices/index.rst
@@ -72,6 +72,7 @@ Tested
   - PA1200
   - PA2200
   - PAX1800 (v1, v2)
+  - PAX1800-Lite
   - PAX5400
 
 * Ubiquiti

--- a/router_tftp_client.c
+++ b/router_tftp_client.c
@@ -131,6 +131,7 @@ void tftp_client_flash_time_set(struct node *node)
 		   (node->router_type == &pa2200.router_type) ||
 		   (node->router_type == &pax1800.router_type) ||
 		   (node->router_type == &pax1800v2.router_type) ||
+		   (node->router_type == &pax1800lite.router_type) ||
 		   (node->router_type == &pax5400.router_type) ||
 		   (node->router_type == &tw420.router_type) ||
 		   (node->router_type == &zyxel.router_type)) {
@@ -171,6 +172,7 @@ int tftp_client_flash_completed(struct node *node)
 		   (node->router_type == &pa2200.router_type) ||
 		   (node->router_type == &pax1800.router_type) ||
 		   (node->router_type == &pax1800v2.router_type) ||
+		   (node->router_type == &pax1800lite.router_type) ||
 		   (node->router_type == &pax5400.router_type) ||
 		   (node->router_type == &tw420.router_type) ||
 		   (node->router_type == &zyxel.router_type)) {
@@ -718,6 +720,28 @@ const struct router_tftp_client pax5400 = {
 	},
 	.mac_accept_entries = pax5400_mac_accept,
 	.mac_accept_entries_num = ARRAY_SIZE(pax5400_mac_accept),
+	.ip = OM2P_IP,
+};
+
+static const struct mac_accept_entry pax1800lite_mac_accept[] = {
+	{
+		.mac = {'P', 'A', 'X', '1', '8', 'L'},
+		.mask = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+	},
+};
+
+const struct router_tftp_client pax1800lite = {
+	.router_type = {
+		.desc = "PAX1800-Lite",
+		.detect_pre = NULL,
+		.detect_main = tftp_client_detect_main,
+		.detect_post = tftp_client_detect_post,
+		.image = &img_ce,
+		.image_desc = "PAX1800-Lite",
+		.priv_size = sizeof(struct om2p_priv),
+	},
+	.mac_accept_entries = pax1800lite_mac_accept,
+	.mac_accept_entries_num = ARRAY_SIZE(pax1800lite_mac_accept),
 	.ip = OM2P_IP,
 };
 

--- a/router_tftp_client.h
+++ b/router_tftp_client.h
@@ -44,6 +44,7 @@ extern const struct router_tftp_client pa1200;
 extern const struct router_tftp_client pa2200;
 extern const struct router_tftp_client pax1800;
 extern const struct router_tftp_client pax1800v2;
+extern const struct router_tftp_client pax1800lite;
 extern const struct router_tftp_client pax5400;
 extern const struct router_tftp_client tw420;
 extern const struct router_tftp_client zyxel;

--- a/router_types.c
+++ b/router_types.c
@@ -55,6 +55,7 @@ static const struct router_type *router_types[] = {
 	&pa2200.router_type,
 	&pax1800.router_type,
 	&pax1800v2.router_type,
+	&pax1800lite.router_type,
 	&pax5400.router_type,
 	NULL,
 };


### PR DESCRIPTION
Plasma Cloud PAX1800-Lite is a dual-band Wi-Fi 6 router, based on MediaTek MT7621A + MT79x5D platform.

Specifications:

- SOC:      MT7621AT (880 MHz)
- DRAM:     DDR3 448 MiB (Nanya NT5CC256M16DP-DI)
- Flash:    4 MiB SPI NOR (MX25L3233F) + 128 MB SPI NAND (W25N02KVZEIR)
- Ethernet: 1x 10/100/1000 Mbps (SOC's built-in switch, with PoE+)
- Wi-Fi:    2x2:2 2.4/5 GHz (MT7905DAN + MT7975DN)
            (MT7905DAN doesn't support background DFS scan/BT)
- LED:      tri-color LED for status (red, blue, green)
- Buttons:  1x (reset)
- Antenna:  4x internal, non-detachable omnidirectional
- UART:     1x 4-pin (2.54 mm pitch, marked as "3V3 G/RX GND W/TX")
- Power:    12 V DC/2 A (DC jack)

MAC addresses:

WAN:     54:9C:27:xx:xx:00 (factory 0x3fff4, device label)
2.4 GHz: 54:9C:27:xx:xx:02 (factory 0x4, +2)
5 GHz:   54:9C:27:xx:xx:08 (factory 0xa, +8)